### PR TITLE
Watcher Fix Compliation Pull Request

### DIFF
--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -63,7 +63,7 @@ extension WebSocket: Hashable {
   }
 }
 
-public actor Server {
+public class Server {
   /// Used for decoding `Event` values sent from the WebSocket client.
   private let decoder = JSONDecoder()
 


### PR DESCRIPTION
Server inheriting from Actor casued the watcher onChange task to not execute.
Inhertiting from class appears to fix everything as teh watcher sees changes build and refreshes.
I and andrewbara stumbled upon this but are not aware of the implications of the change.
I